### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
       id-token: write  # Required for trusted publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for setuptools-scm to get version from tags
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,12 @@ name = "import-analyzer-py"
 dynamic = ["version"]
 description = "A Python import analyzer with cross-file analysis, unused import detection, and autofix"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- Use `fetch-depth: 0` in publish job for setuptools-scm (fixes shallow clone warning)
- Update license format to PEP 639 style (`license = "MIT"`)
- Remove deprecated license classifier

Fixes warnings from https://github.com/cmyui/import-analyzer-py/actions/runs/20876855135

🤖 Generated with [Claude Code](https://claude.ai/code)