### PR TITLE
Add import-analyzer pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,8 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
+
+  - repo: https://github.com/cmyui/import-analyzer-py
+    rev: v0.1.3
+    hooks:
+      - id: import-analyzer


### PR DESCRIPTION
## Summary
Add import-analyzer as a pre-commit hook for this repo using v0.1.3 from the public repo.

## Test plan
- [x] Pre-commit hook passes locally

🤖 Generated with [Claude Code](https://claude.ai/code)