### PR TITLE
Add indirect import detection and autofix

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,7 +6,7 @@
   language: python
   types: [python]
   pass_filenames: false
-  args: [., --fix, --warn-implicit-reexports, --warn-circular, --warn-unreachable]
+  args: [., --fix-unused-imports, --warn-implicit-reexports, --warn-circular, --warn-unreachable]
 
 # Single-file analysis - only analyzes changed files (faster, less thorough)
 - id: import-analyzer-single-file
@@ -15,4 +15,4 @@
   entry: import-analyzer
   language: python
   types: [python]
-  args: [--single-file, --fix]
+  args: [--single-file, --fix-unused-imports]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![build status](https://github.com/cmyui/import-analyzer-py/actions/workflows/ci.yml/badge.svg)](https://github.com/cmyui/import-analyzer-py/actions/workflows/ci.yml)
 
+> **Warning**: This project is in early development and will undergo significant changes. The API is not stable and may change without notice.
+
 A Python import analyzer with cross-file analysis, unused import detection, circular import warnings, and autofix.
 
 ## Comparison with Other Tools

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![build status](https://github.com/cmyui/import-analyzer-py/actions/workflows/ci.yml/badge.svg)](https://github.com/cmyui/import-analyzer-py/actions/workflows/ci.yml)
 
-> **Warning**: This project is in early development and will undergo significant changes. The API is not stable and may change without notice.
+> [!WARNING]
+> This project is in early development and will undergo significant changes. The API is not stable and may change without notice.
 
 A Python import analyzer with cross-file analysis, unused import detection, circular import warnings, and autofix.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ repos:
 ```
 
 The cross-file hook runs with all features enabled by default:
-`--fix --warn-implicit-reexports --warn-circular --warn-unreachable`
+`--fix-unused-imports --warn-implicit-reexports --warn-circular --warn-unreachable`
 
 To customize:
 
@@ -98,7 +98,7 @@ hooks:
   - id: import-analyzer
     args: [.]  # check only, no warnings
   - id: import-analyzer
-    args: [., --fix]  # fix but no warnings
+    args: [., --fix-unused-imports]  # fix but no warnings
 ```
 
 ## Usage
@@ -115,7 +115,7 @@ import-analyzer main.py
 import-analyzer src/
 
 # Fix all unused imports (including cascaded ones)
-import-analyzer --fix main.py
+import-analyzer --fix-unused-imports main.py
 
 # Warn about implicit re-exports (imports used by other files but not in __all__)
 import-analyzer --warn-implicit-reexports main.py
@@ -146,7 +146,7 @@ import-analyzer --single-file src/*.py
 
 | Code | Meaning                                       |
 | ---- | --------------------------------------------- |
-| 0    | No unused imports found (or `--fix` was used) |
+| 0    | No unused imports found (or `--fix-unused-imports` was used) |
 | 1    | Unused imports found                          |
 
 ## Features
@@ -210,7 +210,7 @@ def get_home() -> Optional[Path]:
     return Path(os.environ.get("HOME"))
 ```
 
-After (`--fix`):
+After (`--fix-unused-imports`):
 
 ```python
 import os
@@ -247,7 +247,7 @@ from utils import List    # becomes unused when main.py's import is removed
 from typing import List   # becomes unused when helpers.py's import is removed
 ```
 
-Running `import-analyzer --fix main.py` removes all three imports in a single pass.
+Running `import-analyzer --fix-unused-imports main.py` removes all three imports in a single pass.
 
 Note: Imports listed in `__all__` are always considered "used" (public API declaration) and won't be removed by cascade detection. This matches the behavior of flake8, ruff, and autoflake.
 

--- a/import_analyzer/__init__.py
+++ b/import_analyzer/__init__.py
@@ -8,6 +8,7 @@ from import_analyzer._cross_file import analyze_cross_file
 from import_analyzer._data import ImplicitReexport
 from import_analyzer._data import ImportEdge
 from import_analyzer._data import ImportInfo
+from import_analyzer._data import IndirectImport
 from import_analyzer._data import ModuleInfo
 from import_analyzer._detection import find_unused_imports
 from import_analyzer._graph import ImportGraph
@@ -27,6 +28,7 @@ __all__ = [
     "ModuleInfo",
     "ImportEdge",
     "ImplicitReexport",
+    "IndirectImport",
     "CrossFileResult",
     # Single-file analysis
     "find_unused_imports",

--- a/import_analyzer/_autofix.py
+++ b/import_analyzer/_autofix.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import ast
+from collections import defaultdict
+from pathlib import Path
 
 from import_analyzer._data import ImportInfo
+from import_analyzer._data import IndirectImport
 
 
 def _find_block_only_imports(
@@ -102,15 +105,24 @@ def _find_semicolon_removals(
     # (statements with content on the same physical line)
     stmts_by_line: dict[int, list[ast.stmt]] = {}
     for node in ast.walk(tree):
-        if isinstance(node, ast.stmt) and hasattr(node, 'lineno'):
+        if isinstance(node, ast.stmt) and hasattr(node, "lineno"):
             end_lineno = node.end_lineno or node.lineno
             # For compound statements (if, for, etc.), skip them as they
             # contain other statements rather than being semicolon-separated
             if isinstance(
-                node, (
-                    ast.If, ast.For, ast.AsyncFor, ast.While, ast.With,
-                    ast.AsyncWith, ast.Try, ast.FunctionDef, ast.AsyncFunctionDef,
-                    ast.ClassDef, ast.Match,
+                node,
+                (
+                    ast.If,
+                    ast.For,
+                    ast.AsyncFor,
+                    ast.While,
+                    ast.With,
+                    ast.AsyncWith,
+                    ast.Try,
+                    ast.FunctionDef,
+                    ast.AsyncFunctionDef,
+                    ast.ClassDef,
+                    ast.Match,
                 ),
             ):
                 continue
@@ -148,7 +160,7 @@ def _find_semicolon_removals(
 
             # This import should be removed - calculate the range
             start_col = stmt.col_offset
-            end_col = stmt.end_col_offset or len(line.rstrip('\n'))
+            end_col = stmt.end_col_offset or len(line.rstrip("\n"))
 
             # Determine if we need to include semicolon before or after
             # Handle any whitespace (spaces, tabs) around semicolons
@@ -156,18 +168,18 @@ def _find_semicolon_removals(
                 # First statement - remove trailing whitespace, semicolon, whitespace
                 rest = line[end_col:]
                 # Strip: optional whitespace, semicolon, optional whitespace
-                stripped = rest.lstrip(' \t')
-                if stripped.startswith(';'):
-                    stripped = stripped[1:].lstrip(' \t')
+                stripped = rest.lstrip(" \t")
+                if stripped.startswith(";"):
+                    stripped = stripped[1:].lstrip(" \t")
                 # Calculate how much extra to remove
                 end_col += len(rest) - len(stripped)
             else:
                 # Not first - remove leading whitespace, semicolon, whitespace
                 prefix = line[:start_col]
                 # Strip from right: optional whitespace, semicolon, optional whitespace
-                stripped = prefix.rstrip(' \t')
-                if stripped.endswith(';'):
-                    stripped = stripped[:-1].rstrip(' \t')
+                stripped = prefix.rstrip(" \t")
+                if stripped.endswith(";"):
+                    stripped = stripped[:-1].rstrip(" \t")
                 # Calculate new start position
                 start_col = len(stripped)
 
@@ -175,7 +187,9 @@ def _find_semicolon_removals(
 
             # For multiline imports, also mark preceding lines for removal
             if stmt.lineno != stmt.end_lineno:
-                for remove_line in range(stmt.lineno - 1, (stmt.end_lineno or stmt.lineno) - 1):
+                for remove_line in range(
+                    stmt.lineno - 1, (stmt.end_lineno or stmt.lineno) - 1,
+                ):
                     lines_to_remove.add(remove_line)
 
         if line_removals:
@@ -198,7 +212,9 @@ def remove_unused_imports(source: str, unused_imports: list[ImportInfo]) -> str:
 
     # Find surgical removals for semicolon lines
     semicolon_removals, semicolon_lines_to_remove = _find_semicolon_removals(
-        tree, source, unused_names,
+        tree,
+        source,
+        unused_names,
     )
 
     # Group unused imports by their statement line
@@ -376,15 +392,15 @@ def remove_unused_imports(source: str, unused_imports: list[ImportInfo]) -> str:
     cleaned_backslash: list[str] = []
     for idx, line in enumerate(result_lines):
         # Check if this line ends with backslash continuation
-        line_content = line.rstrip('\n\r')
-        if line_content.rstrip(' \t').endswith('\\'):
+        line_content = line.rstrip("\n\r")
+        if line_content.rstrip(" \t").endswith("\\"):
             # Check if next line exists and has content (not just whitespace)
             next_idx = idx + 1
             if next_idx >= len(result_lines) or not result_lines[next_idx].strip():
                 # Remove the trailing backslash and whitespace/semicolon before it
-                stripped = line_content.rstrip(' \t')[:-1].rstrip(' \t;')
+                stripped = line_content.rstrip(" \t")[:-1].rstrip(" \t;")
                 if stripped:
-                    cleaned_backslash.append(stripped + '\n')
+                    cleaned_backslash.append(stripped + "\n")
                 # else: line becomes empty, skip it
                 continue
         cleaned_backslash.append(line)
@@ -401,7 +417,7 @@ def remove_unused_imports(source: str, unused_imports: list[ImportInfo]) -> str:
                 first_content_idx = idx
                 break
         first_line = result_lines[first_content_idx]
-        if first_line and first_line[0] in ' \t':
+        if first_line and first_line[0] in " \t":
             # First content line has leading whitespace - strip it
             result_lines[first_content_idx] = first_line.lstrip()
         result = "".join(result_lines)
@@ -426,3 +442,117 @@ def remove_unused_imports(source: str, unused_imports: list[ImportInfo]) -> str:
             cleaned_lines.append(line)
 
     return "".join(cleaned_lines)
+
+
+def fix_indirect_imports(
+    source: str,
+    indirect_imports: list[IndirectImport],
+    module_names: dict[Path, str],
+) -> str:
+    """Rewrite indirect imports to use direct sources.
+
+    Args:
+        source: The source code to modify
+        indirect_imports: List of indirect imports to fix
+        module_names: Mapping from file paths to module names
+
+    Returns:
+        Modified source code with indirect imports replaced
+    """
+    if not indirect_imports:
+        return source
+
+    # Build lookup: (lineno, name) -> original_source module name
+    indirect_by_line: dict[int, dict[str, str]] = defaultdict(dict)
+    for ind in indirect_imports:
+        module_name = module_names.get(ind.original_source)
+        if module_name:
+            indirect_by_line[ind.lineno][ind.name] = module_name
+
+    if not indirect_by_line:
+        return source
+
+    tree = ast.parse(source)
+    lines = source.splitlines(keepends=True)
+
+    # Find ImportFrom nodes that need modification
+    modifications: list[tuple[int, int, str]] = []  # (start_line, end_line, new_code)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        line_idx = node.lineno
+        if line_idx not in indirect_by_line:
+            continue
+
+        indirect_names = indirect_by_line[line_idx]
+
+        # Get all aliases in this import
+        aliases = [(alias.name, alias.asname) for alias in node.names]
+
+        # Separate into indirect and direct imports
+        # Group indirect imports by their target module
+        indirect_by_module: dict[str, list[tuple[str, str | None]]] = defaultdict(list)
+        direct_imports: list[tuple[str, str | None]] = []
+
+        for name, asname in aliases:
+            local_name = asname or name
+            if local_name in indirect_names:
+                target_module = indirect_names[local_name]
+                indirect_by_module[target_module].append((name, asname))
+            else:
+                direct_imports.append((name, asname))
+
+        if not indirect_by_module:
+            continue
+
+        # Get original indentation
+        original_line = lines[node.lineno - 1]
+        indent = len(original_line) - len(original_line.lstrip())
+        indent_str = " " * indent
+
+        # Build new import lines
+        new_imports: list[str] = []
+
+        # Keep direct imports from original module (if any)
+        if direct_imports:
+            parts = []
+            for name, asname in direct_imports:
+                if asname:
+                    parts.append(f"{name} as {asname}")
+                else:
+                    parts.append(name)
+            module = node.module or ""
+            level = "." * node.level
+            new_imports.append(
+                f"{indent_str}from {level}{module} import {', '.join(parts)}",
+            )
+
+        # Add new imports from original sources
+        for module, names in sorted(indirect_by_module.items()):
+            parts = []
+            for name, asname in names:
+                if asname:
+                    parts.append(f"{name} as {asname}")
+                else:
+                    parts.append(name)
+            new_imports.append(f"{indent_str}from {module} import {', '.join(parts)}")
+
+        new_code = "\n".join(new_imports)
+        end_line = node.end_lineno or node.lineno
+        modifications.append((node.lineno - 1, end_line - 1, new_code))
+
+    if not modifications:
+        return source
+
+    # Apply modifications in reverse order to preserve line numbers
+    modifications.sort(key=lambda x: x[0], reverse=True)
+
+    for start_line, end_line, new_code in modifications:
+        # Replace lines from start_line to end_line (inclusive) with new_code
+        before = lines[:start_line]
+        after = lines[end_line + 1:]
+        lines = before + [new_code + "\n"] + after
+
+    return "".join(lines)

--- a/import_analyzer/_cross_file.py
+++ b/import_analyzer/_cross_file.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from import_analyzer._data import ImplicitReexport
 from import_analyzer._data import ImportInfo
+from import_analyzer._data import IndirectImport
 from import_analyzer._detection import find_unused_imports
 from import_analyzer._graph import ImportGraph
 
@@ -22,6 +23,9 @@ class CrossFileResult:
     # Imports used by other files but not in __all__
     implicit_reexports: list[ImplicitReexport] = field(default_factory=list)
 
+    # Imports going through re-exporters instead of direct sources
+    indirect_imports: list[IndirectImport] = field(default_factory=list)
+
     # External module usage across the project: module -> files using it
     external_usage: dict[str, set[Path]] = field(default_factory=dict)
 
@@ -35,9 +39,15 @@ class CrossFileResult:
 class CrossFileAnalyzer:
     """Analyze imports across multiple files."""
 
-    def __init__(self, graph: ImportGraph, entry_point: Path | None = None) -> None:
+    def __init__(
+        self,
+        graph: ImportGraph,
+        entry_point: Path | None = None,
+        include_same_package_indirect: bool = False,
+    ) -> None:
         self.graph = graph
         self.entry_point = entry_point
+        self.include_same_package_indirect = include_same_package_indirect
 
     def analyze(self) -> CrossFileResult:
         """Run cross-file analysis.
@@ -143,6 +153,9 @@ class CrossFileAnalyzer:
         # Filter to only files that are truly dead code (no reachable ancestors)
         truly_unreachable = self._filter_truly_unreachable(unreachable_files, all_removed)
         result.unreachable_files = truly_unreachable - {self.entry_point}
+
+        # Step 9: Find indirect imports (imports through re-exporters)
+        result.indirect_imports = self._find_indirect_imports()
 
         return result
 
@@ -406,10 +419,151 @@ class CrossFileAnalyzer:
 
         return dict(usage)
 
+    def _find_indirect_imports(self) -> list[IndirectImport]:
+        """Find imports that go through re-exporters instead of direct sources.
+
+        An indirect import is when file A imports name X from file B,
+        but B doesn't define X - it imports X from file C.
+
+        By default, same-package re-exports are allowed (e.g., pkg/__init__.py
+        re-exporting from pkg/module.py). Use include_same_package_indirect=True
+        to flag those as well.
+        """
+        results: list[IndirectImport] = []
+
+        for edge in self.graph.edges:
+            if edge.is_external or edge.imported is None:
+                continue
+
+            imported_module = self.graph.nodes.get(edge.imported)
+            if not imported_module:
+                continue
+
+            # For each name imported from this module
+            for name in edge.names:
+                # Check if this name is a re-export (import, not definition)
+                if name in imported_module.defined_names:
+                    continue  # Defined here, not indirect
+
+                # Find where this module got the name from
+                original_source = self._trace_import_source(edge.imported, name)
+                if original_source is None or original_source == edge.imported:
+                    continue  # Can't trace or already at source
+
+                # Check if same-package re-export
+                is_same_pkg = self._is_same_package_reexport(
+                    edge.imported,
+                    original_source,
+                )
+
+                if is_same_pkg and not self.include_same_package_indirect:
+                    continue  # Skip same-package re-exports by default
+
+                # Find the line number for this import
+                lineno = self._find_import_lineno(edge.importer, edge.imported, name)
+
+                results.append(
+                    IndirectImport(
+                        file=edge.importer,
+                        name=name,
+                        lineno=lineno,
+                        current_source=edge.imported,
+                        original_source=original_source,
+                        is_same_package=is_same_pkg,
+                    ),
+                )
+
+        # Sort by file, then line number for consistent output
+        results.sort(key=lambda x: (x.file, x.lineno, x.name))
+        return results
+
+    def _trace_import_source(self, file: Path, name: str) -> Path | None:
+        """Trace an import back to its original definition.
+
+        Follows the import chain until we find a file that actually defines
+        the name (not just re-exports it).
+        """
+        visited: set[Path] = set()
+        current = file
+
+        while current not in visited:
+            visited.add(current)
+            module = self.graph.nodes.get(current)
+            if not module:
+                return None
+
+            # If defined here, this is the source
+            if name in module.defined_names:
+                return current
+
+            # Find where this module imports the name from
+            found_next = False
+            for imp in module.imports:
+                if imp.name == name:
+                    # Find the edge for this import
+                    for edge in self.graph.get_imports(current):
+                        if name in edge.names and edge.imported:
+                            current = edge.imported
+                            found_next = True
+                            break
+                    break
+
+            if not found_next:
+                return None  # Can't trace further
+
+        return None  # Circular, can't determine
+
+    def _is_same_package_reexport(self, reexporter: Path, source: Path) -> bool:
+        """Check if reexporter is __init__.py re-exporting from its own package.
+
+        Returns True if:
+        1. reexporter is an __init__.py file, AND
+        2. source is within the same package directory
+
+        This pattern is acceptable because __init__.py commonly defines
+        the public API of a package by re-exporting from submodules.
+        """
+        if reexporter.name != "__init__.py":
+            return False
+
+        # Get the package directory (parent of __init__.py)
+        pkg_dir = reexporter.parent.resolve()
+        source_resolved = source.resolve()
+
+        # Check if source is within the package directory
+        try:
+            source_resolved.relative_to(pkg_dir)
+            return True
+        except ValueError:
+            return False
+
+    def _find_import_lineno(
+        self,
+        importer: Path,
+        imported: Path,
+        name: str,
+    ) -> int:
+        """Find the line number of a specific import in a file."""
+        module = self.graph.nodes.get(importer)
+        if not module:
+            return 0
+
+        # Look for the import that matches both the source and name
+        for imp in module.imports:
+            if imp.name == name:
+                # Verify this import is from the right module
+                for edge in self.graph.get_imports(importer):
+                    if edge.imported == imported and name in edge.names:
+                        return imp.lineno
+
+        return 0
+
 
 def analyze_cross_file(
-    graph: ImportGraph, entry_point: Path | None = None,
+    graph: ImportGraph,
+    entry_point: Path | None = None,
+    include_same_package_indirect: bool = False,
 ) -> CrossFileResult:
     """Convenience function for cross-file analysis."""
-    analyzer = CrossFileAnalyzer(graph, entry_point)
+    analyzer = CrossFileAnalyzer(graph, entry_point, include_same_package_indirect)
     return analyzer.analyze()

--- a/import_analyzer/_data.py
+++ b/import_analyzer/_data.py
@@ -60,7 +60,7 @@ class ImplicitReexport:
 class IndirectImport:
     """An import that goes through a re-exporter instead of the source.
 
-    Example:
+    Example (without alias):
         # core.py
         CONFIG = {}  # Original definition
 
@@ -72,10 +72,24 @@ class IndirectImport:
 
         # app.py (DIRECT - what it should be)
         from core import CONFIG  # Importing from source
+
+    Example (with alias):
+        # core.py
+        CONFIG = {}  # Original definition
+
+        # utils/__init__.py
+        from core import CONFIG as CONF  # Re-exports with alias
+
+        # app.py (INDIRECT)
+        from utils import CONF
+
+        # app.py (DIRECT - preserves the alias)
+        from core import CONFIG as CONF
     """
 
     file: Path  # File with the indirect import
-    name: str  # Name being imported indirectly
+    name: str  # Name as used in the importing file (e.g., "CONF")
+    original_name: str  # Name as defined in original_source (e.g., "CONFIG")
     lineno: int  # Line number of the import
     current_source: Path  # Where it's imported from (re-exporter)
     original_source: Path  # Where it's actually defined

--- a/import_analyzer/_data.py
+++ b/import_analyzer/_data.py
@@ -56,6 +56,32 @@ class ImplicitReexport:
     used_by: set[Path] = field(default_factory=set)
 
 
+@dataclass
+class IndirectImport:
+    """An import that goes through a re-exporter instead of the source.
+
+    Example:
+        # core.py
+        CONFIG = {}  # Original definition
+
+        # utils/__init__.py
+        from core import CONFIG  # Re-exports CONFIG
+
+        # app.py (INDIRECT - this is what we detect)
+        from utils import CONFIG  # Importing from re-exporter
+
+        # app.py (DIRECT - what it should be)
+        from core import CONFIG  # Importing from source
+    """
+
+    file: Path  # File with the indirect import
+    name: str  # Name being imported indirectly
+    lineno: int  # Line number of the import
+    current_source: Path  # Where it's imported from (re-exporter)
+    original_source: Path  # Where it's actually defined
+    is_same_package: bool  # True if re-exporter is __init__.py of original's package
+
+
 def is_under_path(file_path: Path, base_path: Path) -> bool:
     """Check if a file is under the base path."""
     try:

--- a/import_analyzer/_format.py
+++ b/import_analyzer/_format.py
@@ -25,7 +25,7 @@ def make_relative(path: Path, base: Path) -> str:
 def format_cross_file_results(
     result: CrossFileResult,
     base_path: Path,
-    fix: bool = False,
+    fix_unused: bool = False,
     warn_implicit_reexports: bool = False,
     warn_circular: bool = False,
     warn_unreachable: bool = False,
@@ -37,7 +37,7 @@ def format_cross_file_results(
     Args:
         result: The cross-file analysis result
         base_path: Base path for making paths relative (also filters results)
-        fix: Whether we're in fix mode
+        fix_unused: Whether we're in fix mode
         warn_implicit_reexports: Whether to show implicit re-export warnings
         warn_circular: Whether to show circular import warnings
         warn_unreachable: Whether to show unreachable file warnings
@@ -68,7 +68,7 @@ def format_cross_file_results(
     # Section 1: Unused imports (grouped by file, then by line)
     if filtered_unused and not quiet:
         lines.extend(
-            _format_unused_imports(filtered_unused, base_path, fix, fixed_files),
+            _format_unused_imports(filtered_unused, base_path, fix_unused, fixed_files),
         )
 
     # Section 2: Implicit re-exports (filtered to base_path)
@@ -109,7 +109,7 @@ def format_cross_file_results(
             total_unused,
             total_files,
             len(filtered_unreachable) if warn_unreachable else 0,
-            fix,
+            fix_unused,
         ),
     )
 
@@ -119,7 +119,7 @@ def format_cross_file_results(
 def _format_unused_imports(
     unused_imports: dict[Path, list[ImportInfo]],
     base_path: Path,
-    fix: bool,
+    fix_unused: bool,
     fixed_files: dict[Path, int] | None,
 ) -> list[str]:
     """Format unused imports grouped by file and line."""
@@ -145,7 +145,7 @@ def _format_unused_imports(
             lines.extend(_format_line_imports(lineno, imps))
 
         # Add "fixed" note if applicable
-        if fix and fixed_files and file_path in fixed_files:
+        if fix_unused and fixed_files and file_path in fixed_files:
             count = fixed_files[file_path]
             lines.append(f"  └─ Fixed {count} import(s)")
 
@@ -299,7 +299,7 @@ def _format_summary(
     total_unused: int,
     total_files: int,
     unreachable_count: int,
-    fix: bool,
+    fix_unused: bool,
 ) -> list[str]:
     """Format the summary line."""
     lines: list[str] = []
@@ -309,7 +309,7 @@ def _format_summary(
         lines.append("No unused imports found")
     else:
         parts: list[str] = []
-        action = "Fixed" if fix else "Found"
+        action = "Fixed" if fix_unused else "Found"
 
         if total_unused > 0:
             if total_files == 1:

--- a/import_analyzer/_graph.py
+++ b/import_analyzer/_graph.py
@@ -384,8 +384,8 @@ class GraphBuilder:
                 for name in names:
                     # Only check for submodule if name is NOT already available
                     # from the __init__.py. This handles cases like:
-                    # - `from models import Foo` where Foo is re-exported in __init__.py
-                    # - `from mypkg import submodule` where submodule is
+                    # - `from pkg import Foo` where Foo is re-exported in __init__.py
+                    # - `from pkg import submodule` where submodule is
                     #   a subpackage NOT imported in __init__.py
                     if name in init_names:
                         continue

--- a/import_analyzer/_main.py
+++ b/import_analyzer/_main.py
@@ -101,7 +101,9 @@ def check_cross_file(
     indirect_fixed_files: dict[Path, int] = {}
     if fix_indirect and result.indirect_imports:
         indirect_fixed_files = _fix_indirect_imports(
-            result.indirect_imports, graph, path,
+            result.indirect_imports,
+            graph,
+            path,
         )
 
     # Filter results to only files under the target path

--- a/import_analyzer/_main.py
+++ b/import_analyzer/_main.py
@@ -2,19 +2,23 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections import defaultdict
 from pathlib import Path
 
+from import_analyzer._autofix import fix_indirect_imports
 from import_analyzer._autofix import remove_unused_imports
 from import_analyzer._cross_file import analyze_cross_file
 from import_analyzer._data import ImportInfo
+from import_analyzer._data import IndirectImport
 from import_analyzer._data import is_under_path
 from import_analyzer._detection import find_unused_imports
 from import_analyzer._format import format_cross_file_results
+from import_analyzer._graph import ImportGraph
 from import_analyzer._graph import build_import_graph
 from import_analyzer._graph import build_import_graph_from_directory
 
 
-def check_file(filepath: Path, fix: bool = False) -> tuple[int, list[str]]:
+def check_file(filepath: Path, fix_unused: bool = False) -> tuple[int, list[str]]:
     """Check a file for unused imports (single-file mode).
 
     Returns:
@@ -40,7 +44,7 @@ def check_file(filepath: Path, fix: bool = False) -> tuple[int, list[str]]:
             msg = f"{filepath}:{imp.lineno}: Unused import '{imp.name}'"
         messages.append(msg)
 
-    if fix:
+    if fix_unused:
         new_source = remove_unused_imports(source, unused)
         if new_source != source:
             filepath.write_text(new_source)
@@ -53,20 +57,24 @@ def check_file(filepath: Path, fix: bool = False) -> tuple[int, list[str]]:
 
 def check_cross_file(
     path: Path,
-    fix: bool = False,
+    fix_unused: bool = False,
+    fix_indirect: bool = False,
     warn_implicit_reexports: bool = False,
     warn_circular: bool = False,
     warn_unreachable: bool = False,
+    strict_indirect_imports: bool = False,
     quiet: bool = False,
 ) -> tuple[int, list[str]]:
     """Check imports across files (cross-file mode).
 
     Args:
         path: Entry point file or directory to analyze
-        fix: Whether to fix unused imports
+        fix_unused: Whether to fix unused imports
+        fix_indirect: Whether to fix indirect imports (rewrite to direct sources)
         warn_implicit_reexports: Whether to warn about implicit re-exports
         warn_circular: Whether to warn about circular imports
         warn_unreachable: Whether to warn about unreachable files
+        strict_indirect_imports: Also flag same-package __init__.py re-exports
         quiet: Whether to suppress individual issue messages
 
     Returns:
@@ -82,7 +90,19 @@ def check_cross_file(
         # No single entry point for directory mode
 
     # Analyze (pass entry point for file reachability tracking)
-    result = analyze_cross_file(graph, entry_point)
+    result = analyze_cross_file(
+        graph,
+        entry_point,
+        include_same_package_indirect=strict_indirect_imports,
+    )
+
+    # Fix indirect imports first (if requested)
+    # This enables cascade: after fixing indirect imports, the re-exports become unused
+    indirect_fixed_files: dict[Path, int] = {}
+    if fix_indirect and result.indirect_imports:
+        indirect_fixed_files = _fix_indirect_imports(
+            result.indirect_imports, graph, path,
+        )
 
     # Filter results to only files under the target path
     # (graph may include files discovered via imports outside the target directory)
@@ -90,7 +110,8 @@ def check_cross_file(
     target_path = target_path.resolve()
 
     filtered_unused = {
-        fp: unused for fp, unused in result.unused_imports.items()
+        fp: unused
+        for fp, unused in result.unused_imports.items()
         if is_under_path(fp, target_path)
     }
 
@@ -99,7 +120,7 @@ def check_cross_file(
 
     # Fix files if requested (only files under target path)
     fixed_files: dict[Path, int] = {}
-    if fix:
+    if fix_unused:
         for file_path, unused in filtered_unused.items():
             count = _fix_file_silent(file_path, unused)
             if count > 0:
@@ -109,13 +130,22 @@ def check_cross_file(
     messages = format_cross_file_results(
         result=result,
         base_path=path,
-        fix=fix,
+        fix_unused=fix_unused,
         warn_implicit_reexports=warn_implicit_reexports,
         warn_circular=warn_circular,
         warn_unreachable=warn_unreachable,
         quiet=quiet,
         fixed_files=fixed_files,
     )
+
+    # Add indirect fix summary if we fixed any
+    if indirect_fixed_files:
+        total_indirect = sum(indirect_fixed_files.values())
+        messages.insert(
+            0,
+            f"Fixed {total_indirect} indirect import(s) in {len(indirect_fixed_files)} file(s)",
+        )
+        messages.insert(1, "")
 
     return total_issues, messages
 
@@ -141,6 +171,60 @@ def _fix_file_silent(
     return 0
 
 
+def _fix_indirect_imports(
+    indirect_imports: list[IndirectImport],
+    graph: ImportGraph,
+    base_path: Path,
+) -> dict[Path, int]:
+    """Fix indirect imports by rewriting them to use direct sources.
+
+    Args:
+        indirect_imports: List of indirect imports to fix
+        graph: The import graph (for module name lookup)
+        base_path: Base path for filtering (only fix files under this path)
+
+    Returns:
+        Dict mapping file paths to number of imports fixed
+    """
+
+    # Filter to only files under base_path
+    if base_path.is_file():
+        base_path = base_path.parent
+    base_path = base_path.resolve()
+
+    filtered_indirect = [
+        ind for ind in indirect_imports if is_under_path(ind.file, base_path)
+    ]
+
+    if not filtered_indirect:
+        return {}
+
+    # Build module name lookup from graph
+    module_names: dict[Path, str] = {}
+    for file_path, module_info in graph.nodes.items():
+        module_names[file_path] = module_info.module_name
+
+    # Group indirect imports by file
+    by_file: dict[Path, list[IndirectImport]] = defaultdict(list)
+    for ind in filtered_indirect:
+        by_file[ind.file].append(ind)
+
+    # Fix each file
+    fixed_files: dict[Path, int] = {}
+    for file_path, file_indirect in by_file.items():
+        try:
+            source = file_path.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        new_source = fix_indirect_imports(source, file_indirect, module_names)
+        if new_source != source:
+            file_path.write_text(new_source)
+            fixed_files[file_path] = len(file_indirect)
+
+    return fixed_files
+
+
 def collect_python_files(paths: list[Path]) -> list[Path]:
     """Collect all Python files from given paths."""
     files: list[Path] = []
@@ -163,7 +247,8 @@ def main() -> int:
 Examples:
   %(prog)s main.py                   Cross-file analysis from entry point
   %(prog)s src/                      Cross-file analysis of directory
-  %(prog)s --fix main.py             Fix unused imports
+  %(prog)s --fix-unused-imports main.py       Fix unused imports
+  %(prog)s --fix-indirect-imports main.py     Fix indirect imports
   %(prog)s --warn-implicit-reexports main.py
   %(prog)s --warn-circular main.py
   %(prog)s --warn-unreachable main.py
@@ -177,8 +262,9 @@ Examples:
         help="Files or directories to check",
     )
     parser.add_argument(
-        "--fix",
+        "--fix-unused-imports",
         action="store_true",
+        dest="fix_unused",
         help="Automatically remove unused imports",
     )
     parser.add_argument(
@@ -207,6 +293,17 @@ Examples:
         action="store_true",
         help="Warn about files that become unreachable after fixing imports",
     )
+    parser.add_argument(
+        "--strict-indirect-imports",
+        action="store_true",
+        help="Also flag same-package __init__.py re-exports (use with --fix-indirect-imports)",
+    )
+    parser.add_argument(
+        "--fix-indirect-imports",
+        action="store_true",
+        dest="fix_indirect",
+        help="Rewrite indirect imports to use direct sources",
+    )
 
     args = parser.parse_args()
 
@@ -229,7 +326,7 @@ def _main_single_file(args: argparse.Namespace) -> int:
     total_files_with_issues = 0
 
     for filepath in files:
-        count, messages = check_file(filepath, fix=args.fix)
+        count, messages = check_file(filepath, fix_unused=args.fix_unused)
         if count > 0:
             total_unused += count
             total_files_with_issues += 1
@@ -238,12 +335,12 @@ def _main_single_file(args: argparse.Namespace) -> int:
                     print(msg)
 
     if total_unused > 0:
-        action = "Fixed" if args.fix else "Found"
+        action = "Fixed" if args.fix_unused else "Found"
         print(
             f"\n{action} {total_unused} unused import(s) "
             f"in {total_files_with_issues} file(s)",
         )
-        return 0 if args.fix else 1
+        return 0 if args.fix_unused else 1
     else:
         print("No unused imports found")
         return 0
@@ -269,10 +366,12 @@ def _main_cross_file(args: argparse.Namespace) -> int:
 
     total_issues, messages = check_cross_file(
         path,
-        fix=args.fix,
+        fix_unused=args.fix_unused,
+        fix_indirect=args.fix_indirect,
         warn_implicit_reexports=args.warn_implicit_reexports,
         warn_circular=args.warn_circular,
         warn_unreachable=args.warn_unreachable,
+        strict_indirect_imports=args.strict_indirect_imports,
         quiet=args.quiet,
     )
 
@@ -281,7 +380,7 @@ def _main_cross_file(args: argparse.Namespace) -> int:
         print(msg)
 
     # Return code: 0 if no issues or fixed, 1 if issues found and not fixed
-    if total_issues > 0 and not args.fix:
+    if total_issues > 0 and not args.fix_unused:
         return 1
     return 0
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -122,11 +122,11 @@ def test_main_with_unused(tmp_path, monkeypatch, capsys):
 
 
 def test_main_with_fix(tmp_path, monkeypatch, capsys):
-    """Test main() with --fix flag."""
+    """Test main() with --fix-unused-imports flag."""
     dirty_file = tmp_path / "dirty.py"
     dirty_file.write_text("import os\nprint('hello')\n")
 
-    monkeypatch.setattr(sys, 'argv', ['prog', '--fix', str(dirty_file)])
+    monkeypatch.setattr(sys, 'argv', ['prog', '--fix-unused-imports', str(dirty_file)])
 
     result = main()
 
@@ -237,7 +237,7 @@ def test_cross_file_reexport_not_unused(tmp_path):
 
 
 def test_cross_file_fix_preserves_reexports(tmp_path):
-    """--fix should preserve re-exported imports."""
+    """--fix-unused-imports should preserve re-exported imports."""
     (tmp_path / "main.py").write_text(
         "from utils import List\nx: List[int] = []\n",
     )
@@ -245,7 +245,7 @@ def test_cross_file_fix_preserves_reexports(tmp_path):
         "from typing import List, Dict\n",
     )
 
-    check_cross_file(tmp_path / "main.py", fix=True)
+    check_cross_file(tmp_path / "main.py", fix_unused=True)
 
     # List should be preserved (re-exported), Dict removed
     utils_content = (tmp_path / "utils.py").read_text()
@@ -363,14 +363,14 @@ def test_main_cross_file_with_warn_circular(tmp_path, monkeypatch, capsys):
 
 
 def test_main_cross_file_fix(tmp_path, monkeypatch, capsys):
-    """Test --fix in cross-file mode."""
+    """Test --fix-unused-imports in cross-file mode."""
     (tmp_path / "main.py").write_text(
         "from utils import List\nx: List[int] = []\n",
     )
     (tmp_path / "utils.py").write_text("from typing import List, Dict\n")
 
     monkeypatch.setattr(
-        sys, 'argv', ['prog', '--fix', str(tmp_path / "main.py")],
+        sys, 'argv', ['prog', '--fix-unused-imports', str(tmp_path / "main.py")],
     )
 
     result = main()

--- a/tests/file_operations_test.py
+++ b/tests/file_operations_test.py
@@ -47,7 +47,7 @@ def test_check_file_finds_unused(tmp_path, content, expected_count, expected_in_
     file_path = tmp_path / 'test.py'
     file_path.write_text(content)
 
-    count, messages = check_file(file_path, fix=False)
+    count, messages = check_file(file_path, fix_unused=False)
 
     assert count == expected_count
     message_text = '\n'.join(messages)
@@ -78,11 +78,11 @@ def test_check_file_finds_unused(tmp_path, content, expected_count, expected_in_
     ),
 )
 def test_check_file_fixes(tmp_path, content, should_not_contain, should_contain):
-    """Test that check_file with fix=True removes unused imports."""
+    """Test that check_file with fix_unused=True removes unused imports."""
     file_path = tmp_path / 'test.py'
     file_path.write_text(content)
 
-    check_file(file_path, fix=True)
+    check_file(file_path, fix_unused=True)
 
     new_content = file_path.read_text()
     assert should_not_contain not in new_content
@@ -95,7 +95,7 @@ def test_check_file_clean(tmp_path):
     file_path = tmp_path / 'test.py'
     file_path.write_text(content)
 
-    count, messages = check_file(file_path, fix=False)
+    count, messages = check_file(file_path, fix_unused=False)
 
     assert count == 0
     assert messages == []
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     file_path = tmp_path / 'test.py'
     file_path.write_text(content)
 
-    check_file(file_path, fix=True)
+    check_file(file_path, fix_unused=True)
 
     fixed_content = file_path.read_text()
     # Should compile without errors

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -61,7 +61,7 @@ def test_format_groups_by_file(tmp_path: Path) -> None:
     }
 
     lines = format_cross_file_results(
-        result, base_path=base, fix=False,
+        result, base_path=base, fix_unused=False,
     )
     output = "\n".join(lines)
 
@@ -95,7 +95,7 @@ def test_format_groups_same_line_imports(tmp_path: Path) -> None:
     }
 
     lines = format_cross_file_results(
-        result, base_path=base, fix=False,
+        result, base_path=base, fix_unused=False,
     )
     output = "\n".join(lines)
 
@@ -125,7 +125,7 @@ def test_format_implicit_reexports_section(tmp_path: Path) -> None:
 
     lines = format_cross_file_results(
         result, base_path=base,
-        warn_implicit_reexports=True, fix=False,
+        warn_implicit_reexports=True, fix_unused=False,
     )
     output = "\n".join(lines)
 
@@ -148,7 +148,7 @@ def test_format_circular_imports_section(tmp_path: Path) -> None:
 
     lines = format_cross_file_results(
         result, base_path=base,
-        warn_circular=True, fix=False,
+        warn_circular=True, fix_unused=False,
     )
     output = "\n".join(lines)
 
@@ -173,7 +173,7 @@ def test_format_long_cycle_abbreviated(tmp_path: Path) -> None:
 
     lines = format_cross_file_results(
         result, base_path=base,
-        warn_circular=True, fix=False,
+        warn_circular=True, fix_unused=False,
     )
     output = "\n".join(lines)
 
@@ -189,7 +189,7 @@ def test_format_summary_when_no_issues(tmp_path: Path) -> None:
     result = CrossFileResult()
 
     lines = format_cross_file_results(
-        result, base_path=base, fix=False,
+        result, base_path=base, fix_unused=False,
     )
     output = "\n".join(lines)
 
@@ -215,7 +215,7 @@ def test_format_summary_with_issues(tmp_path: Path) -> None:
     }
 
     lines = format_cross_file_results(
-        result, base_path=base, fix=False,
+        result, base_path=base, fix_unused=False,
     )
     output = "\n".join(lines)
 
@@ -241,7 +241,7 @@ def test_format_quiet_mode_shows_only_summary(tmp_path: Path) -> None:
     }
 
     lines = format_cross_file_results(
-        result, base_path=base, fix=False, quiet=True,
+        result, base_path=base, fix_unused=False, quiet=True,
     )
     output = "\n".join(lines)
 
@@ -270,7 +270,7 @@ def test_format_fixed_shows_fixed_count(tmp_path: Path) -> None:
 
     lines = format_cross_file_results(
         result, base_path=base,
-        fix=True, fixed_files={file1: 1},
+        fix_unused=True, fixed_files={file1: 1},
     )
     output = "\n".join(lines)
 


### PR DESCRIPTION
## Summary

- Add `--fix-unused-imports` flag (renamed from `--fix`) to automatically remove unused imports
- Add `--fix-indirect-imports` flag to rewrite imports that go through re-exporters to use direct sources
- Add `--strict-indirect-imports` flag to also fix same-package `__init__.py` re-exports
- Correctly handles aliased import chains (preserves local names)
- Autofix cascades with unused import removal

## Example

Before:
```python
# utils/__init__.py
from core import CONFIG  # re-exports CONFIG

# app.py
from utils import CONFIG  # indirect import
```

After running `import-analyzer --fix-indirect-imports app.py`:
```python
# app.py
from core import CONFIG  # now imports from source
```

### With aliases

Before:
```python
# core.py
CONFIG = {}

# utils/__init__.py
from core import CONFIG as CONF

# app.py
from utils import CONF
```

After fix:
```python
# app.py
from core import CONFIG as CONF  # preserves local name
```

## Test plan

- [x] Added tests for indirect import detection (cross-package, multi-hop, same-package)
- [x] Added tests for autofix functionality
- [x] Added tests for aliased import chains (4 new tests)
- [x] Added test for `--strict-indirect-imports` with autofix
- [x] Renamed `--fix` to `--fix-unused-imports` for consistency
- [x] Fixed unused variable warnings in tests
- [x] All 377 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)