### PR TITLE
Better support for type annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,18 @@ import_analyzer/
   - Handles class scope quirk (doesn't enclose nested functions)
 - `DefinitionCollector`: Collects all defined names (classes, functions, variables) in a module
 - `StringAnnotationVisitor`: Parses string literals as type annotations for forward references.
+  - Special handling for typing constructs (matches pyflakes/ruff behavior):
+    - `typing.cast()`: First argument treated as annotation context
+    - `TypeVar()`: Constraints and `bound` keyword treated as annotation contexts
+    - `Literal[]`: Contents are NOT treated as type annotations (literal values)
+    - `Annotated[]`: Only first argument is annotation, rest is metadata
+    - `TypeAlias`: RHS is annotation context when annotated with TypeAlias
+  - Handles `Callable[[args], return]` with string forward references in args
+- `TypeCommentVisitor`: Parses `# type:` comments for type information (PEP 484).
+  - Supports assignment type comments: `x = []  # type: List[int]`
+  - Supports function signature type comments: `def f(x): # type: (int) -> str`
+  - Supports per-argument type comments in function signatures
+  - Handles `for` loop and `with` statement type comments
 - `collect_dunder_all_names`: Extracts names from `__all__` so exports aren't flagged.
 - `AttributeAccessCollector`: Collects `module.attr` usages for `import module` statements (used for indirect attr access detection)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Python import analyzer with cross-file analysis, unused import detection, circ
 | Full scope analysis (LEGB)    |    ✅     |   ✅    |     ⚠️⁶     |    ⚠️⁶     |    ✅    |     ✅     |
 | String annotations            |    ✅     |   ✅    |     ✅      |     ✅     |    ✅    |     ✅     |
 | TYPE_CHECKING blocks          |    ✅     |   ✅    |     ✅      |    ⚠️⁷     |    ✅    |     ✅     |
-| Type comments (`# type:`)     |    ❌     |   ✅    |     ✅      |     ✅     |    ✅    |     ✅     |
+| Type comments (`# type:`)     |    ✅     |   ✅    |     ✅      |     ✅     |    ✅    |     ✅     |
 | Redundant alias (`x as x`)    |    ❌     |   ✅    |     ❌      |     ❌     |    ❌    |     ❌     |
 | Star import suggestions       |    ❌     |   ❌    |     ❌      |     ❌     |    ❌    |     ✅     |
 | Redefinition warnings         |    ❌     |   ✅    |     ❌      |     ✅     |    ✅    |     ❌     |
@@ -52,7 +52,6 @@ A Python import analyzer with cross-file analysis, unused import detection, circ
 
 Based on analysis of other tools' source code:
 
-- **Type comments**: `# type: int` style annotations (PEP 484) are not parsed
 - **Redundant alias detection**: `import X as X` as explicit re-export marker (Ruff feature)
 - **Star import suggestions**: Suggesting specific names to replace `from x import *` (Unimport feature)
 - **Redefinition warnings**: Warning when an import is reassigned before use (Pyflakes feature)
@@ -178,9 +177,16 @@ import-analyzer --single-file src/*.py
 - Recognizes usage in:
   - Function calls and attribute access
   - Type annotations (including forward references / string annotations)
+  - Type comments (`# type: List[int]`)
   - Decorators and base classes
   - Default argument values
   - `__all__` exports
+- **Type annotation handling** (matches pyflakes/ruff behavior):
+  - `typing.cast()`: First argument is annotation context
+  - `TypeVar()`: Constraints and `bound` keyword are annotation contexts
+  - `Literal[]`: Contents are NOT type annotations (literal values)
+  - `Annotated[]`: Only first argument is annotation, rest is metadata
+  - `TypeAlias`: RHS is annotation context
 - Skips `__future__` imports (they have side effects)
 - Respects `# noqa: F401` comments (matches flake8 behavior)
 - Full scope analysis with LEGB rule:
@@ -384,14 +390,15 @@ tox -e py
 │   ├── shadowed_imports_test.py
 │   ├── scope_analysis_test.py
 │   ├── special_imports_test.py
-│   ├── type_annotations_test.py
+│   ├── type_annotations_test.py  # String annotations & typing constructs
+│   ├── type_comments_test.py     # Type comments (# type:)
 │   ├── autofix_test.py
 │   ├── file_operations_test.py
 │   ├── cli_test.py
-│   ├── resolution_test.py   # Module resolution tests
-│   ├── graph_test.py        # Import graph tests
-│   ├── cross_file_test.py   # Cross-file analysis tests
-│   └── format_test.py       # Output formatting tests
+│   ├── resolution_test.py        # Module resolution tests
+│   ├── graph_test.py             # Import graph tests
+│   ├── cross_file_test.py        # Cross-file analysis tests
+│   └── format_test.py            # Output formatting tests
 ├── pyproject.toml
 ├── tox.ini
 └── .github/workflows/ci.yml

--- a/import_analyzer/_ast_helpers.py
+++ b/import_analyzer/_ast_helpers.py
@@ -955,6 +955,400 @@ def collect_type_comment_names(tree: ast.AST) -> set[str]:
     return visitor.used_names
 
 
+@dataclass
+class TypeStringAttrUsage:
+    """Internal: attribute access found in a type string before mapping to source."""
+
+    root_name: str  # "models" in "models.LOGGER"
+    attr_path: list[str]  # ["LOGGER"]
+    lineno: int  # Line number in source
+    col_offset: int  # Column where the attribute access starts
+    end_col_offset: int  # Column where it ends
+    context: str  # "type_comment" or "string_annotation"
+
+
+class TypeStringAttributeCollector(ast.NodeVisitor):
+    """Collect module.attr usages in type comments and string annotations.
+
+    Given source like:
+        import models
+        x = None  # type: models.User
+        y: "models.Config" = None
+
+    This collector produces usages for:
+        - models.User from the type comment
+        - models.Config from the string annotation
+
+    Handles:
+    - Type comments: x = None  # type: models.User
+    - String annotations: x: "models.User" = None
+    - Nested generics: # type: Dict[str, models.User]
+    - Multiple attrs in same type: # type: Tuple[models.User, models.Config]
+    - Aliased imports: import models as m; # type: m.User
+    """
+
+    def __init__(self, module_imports: set[str]) -> None:
+        """Initialize the collector.
+
+        Args:
+            module_imports: Set of names bound by 'import X' or 'import X as Y'
+        """
+        self.module_imports = module_imports
+        self.usages: list[TypeStringAttrUsage] = []
+
+    def _extract_attrs_from_expr(
+        self,
+        expr: ast.expr,
+        type_str: str,
+        lineno: int,
+        base_col: int,
+        context: str,
+    ) -> None:
+        """Extract attribute accesses from a parsed expression."""
+        for node in ast.walk(expr):
+            if not isinstance(node, ast.Attribute):
+                continue
+
+            # Walk up to find the root Name and collect the attribute path
+            attr_path: list[str] = []
+            current: ast.expr = node
+
+            while isinstance(current, ast.Attribute):
+                attr_path.append(current.attr)
+                current = current.value
+
+            # Check if the root is a Name node
+            if not isinstance(current, ast.Name):
+                continue
+
+            root_name = current.id
+
+            # Check if this name refers to an imported module
+            if root_name not in self.module_imports:
+                continue
+
+            # Reverse to get path from root to leaf
+            attr_path.reverse()
+
+            # Build the full attribute string to find in the type string
+            full_attr = f"{root_name}.{'.'.join(attr_path)}"
+
+            # Find position in the type string
+            # Note: There could be multiple occurrences, handle each
+            start = 0
+            while True:
+                pos = type_str.find(full_attr, start)
+                if pos == -1:
+                    break
+
+                # Calculate absolute column positions
+                col_offset = base_col + pos
+                end_col_offset = col_offset + len(full_attr)
+
+                self.usages.append(
+                    TypeStringAttrUsage(
+                        root_name=root_name,
+                        attr_path=attr_path,
+                        lineno=lineno,
+                        col_offset=col_offset,
+                        end_col_offset=end_col_offset,
+                        context=context,
+                    ),
+                )
+
+                # Move past this occurrence
+                start = pos + len(full_attr)
+                break  # Only record once per AST node
+
+    def _process_type_string(
+        self,
+        type_str: str,
+        lineno: int,
+        col_offset: int,
+        context: str,
+    ) -> None:
+        """Parse a type string and extract attribute accesses."""
+        try:
+            parsed = ast.parse(type_str, mode="eval")
+            self._extract_attrs_from_expr(
+                parsed.body, type_str, lineno, col_offset, context,
+            )
+        except SyntaxError:
+            pass
+
+    def _process_func_type_comment(
+        self,
+        type_comment: str,
+        lineno: int,
+        col_offset: int,
+    ) -> None:
+        """Process function signature type comment: (int, str) -> bool"""
+        stripped = type_comment.strip()
+        if stripped.startswith("ignore"):
+            return
+
+        # For function type comments, we need to find where the comment starts
+        # in the source. The type_comment attribute doesn't include "# type:"
+        if " -> " in type_comment:
+            args_part, return_part = type_comment.rsplit(" -> ", 1)
+
+            # Process return type
+            return_start = type_comment.rfind(return_part)
+            self._process_type_string(
+                return_part.strip(),
+                lineno,
+                col_offset + return_start,
+                "type_comment",
+            )
+
+            # Process args: "(int, str)" or "(...)"
+            args_part = args_part.strip()
+            if args_part.startswith("(") and args_part.endswith(")"):
+                args_inner = args_part[1:-1].strip()
+                if args_inner != "...":
+                    # Process each arg individually
+                    current_pos = type_comment.find("(") + 1
+                    for arg_type in self._split_type_args(args_inner):
+                        arg_type_stripped = arg_type.strip()
+                        # Handle *args and **kwargs
+                        if arg_type_stripped.startswith("**"):
+                            arg_type_stripped = arg_type_stripped[2:]
+                        elif arg_type_stripped.startswith("*"):
+                            arg_type_stripped = arg_type_stripped[1:]
+                        if arg_type_stripped:
+                            # Find where this arg starts in the original string
+                            arg_pos = type_comment.find(arg_type.strip(), current_pos)
+                            self._process_type_string(
+                                arg_type_stripped,
+                                lineno,
+                                col_offset + arg_pos,
+                                "type_comment",
+                            )
+                        current_pos += len(arg_type) + 1  # +1 for comma
+        else:
+            self._process_type_string(type_comment, lineno, col_offset, "type_comment")
+
+    def _split_type_args(self, args_str: str) -> list[str]:
+        """Split comma-separated type args, respecting brackets."""
+        result: list[str] = []
+        current: list[str] = []
+        depth = 0
+        for char in args_str:
+            if char == "[":
+                depth += 1
+            elif char == "]":
+                depth -= 1
+            elif char == "," and depth == 0:
+                result.append("".join(current))
+                current = []
+                continue
+            current.append(char)
+        if current:
+            result.append("".join(current))
+        return result
+
+    def _has_annotations(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> bool:
+        """Check if function has any PEP 526 style annotations."""
+        if node.returns:
+            return True
+        all_args = (
+            node.args.args + node.args.posonlyargs + node.args.kwonlyargs
+        )
+        for arg in all_args:
+            if arg.annotation:
+                return True
+        if node.args.vararg and node.args.vararg.annotation:
+            return True
+        if node.args.kwarg and node.args.kwarg.annotation:
+            return True
+        return False
+
+    def _process_string_annotation(
+        self,
+        node: ast.expr | None,
+        lineno: int | None = None,
+    ) -> None:
+        """Process a potential string annotation node."""
+        if node is None:
+            return
+
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            # The col_offset of the string literal (after the quote)
+            # For a string annotation like x: "models.User", the string
+            # starts after the opening quote
+            self._process_type_string(
+                node.value,
+                node.lineno,
+                node.col_offset + 1,  # +1 to skip the opening quote
+                "string_annotation",
+            )
+        elif isinstance(node, ast.Subscript):
+            self._process_string_annotation(node.slice, lineno)
+            self._process_string_annotation(node.value, lineno)
+        elif isinstance(node, ast.Tuple):
+            for elt in node.elts:
+                self._process_string_annotation(elt, lineno)
+        elif isinstance(node, ast.BinOp):
+            self._process_string_annotation(node.left, lineno)
+            self._process_string_annotation(node.right, lineno)
+
+    def _get_func_type_comment_lineno(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> int:
+        """Determine the actual line number of a function type comment.
+
+        For inline type comments (same line as def), returns node.lineno.
+        For body-type comments (first line of body), returns node.body[0].lineno - 1.
+        """
+        # If function has a body and body starts after the def line
+        if node.body and node.body[0].lineno > node.lineno:
+            # Body-type comment is on the line before the first statement
+            # but after the def line
+            return node.body[0].lineno - 1
+        # Inline type comment
+        return node.lineno
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # Process function type_comment if no PEP 526 annotations
+        if node.type_comment and not self._has_annotations(node):
+            # Determine actual line of the type comment
+            type_comment_lineno = self._get_func_type_comment_lineno(node)
+            self._process_func_type_comment(
+                node.type_comment, type_comment_lineno, 0,
+            )
+
+        # Process per-argument type comments
+        all_args = node.args.args + node.args.posonlyargs + node.args.kwonlyargs
+        for arg in all_args:
+            if arg.type_comment and not arg.annotation:
+                self._process_type_string(
+                    arg.type_comment, arg.lineno, 0, "type_comment",
+                )
+        if node.args.vararg and node.args.vararg.type_comment:
+            if not node.args.vararg.annotation:
+                self._process_type_string(
+                    node.args.vararg.type_comment,
+                    node.args.vararg.lineno,
+                    0,
+                    "type_comment",
+                )
+        if node.args.kwarg and node.args.kwarg.type_comment:
+            if not node.args.kwarg.annotation:
+                self._process_type_string(
+                    node.args.kwarg.type_comment,
+                    node.args.kwarg.lineno,
+                    0,
+                    "type_comment",
+                )
+
+        # Process string annotations
+        self._process_string_annotation(node.returns)
+        for arg in all_args:
+            self._process_string_annotation(arg.annotation)
+        if node.args.vararg:
+            self._process_string_annotation(node.args.vararg.annotation)
+        if node.args.kwarg:
+            self._process_string_annotation(node.args.kwarg.annotation)
+
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        # Same as FunctionDef
+        if node.type_comment and not self._has_annotations(node):
+            type_comment_lineno = self._get_func_type_comment_lineno(node)
+            self._process_func_type_comment(
+                node.type_comment, type_comment_lineno, 0,
+            )
+
+        all_args = node.args.args + node.args.posonlyargs + node.args.kwonlyargs
+        for arg in all_args:
+            if arg.type_comment and not arg.annotation:
+                self._process_type_string(
+                    arg.type_comment, arg.lineno, 0, "type_comment",
+                )
+        if node.args.vararg and node.args.vararg.type_comment:
+            if not node.args.vararg.annotation:
+                self._process_type_string(
+                    node.args.vararg.type_comment,
+                    node.args.vararg.lineno,
+                    0,
+                    "type_comment",
+                )
+        if node.args.kwarg and node.args.kwarg.type_comment:
+            if not node.args.kwarg.annotation:
+                self._process_type_string(
+                    node.args.kwarg.type_comment,
+                    node.args.kwarg.lineno,
+                    0,
+                    "type_comment",
+                )
+
+        self._process_string_annotation(node.returns)
+        for arg in all_args:
+            self._process_string_annotation(arg.annotation)
+        if node.args.vararg:
+            self._process_string_annotation(node.args.vararg.annotation)
+        if node.args.kwarg:
+            self._process_string_annotation(node.args.kwarg.annotation)
+
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if node.type_comment:
+            # Type comment on assignment - need to find "# type:" position
+            self._process_type_string(
+                node.type_comment, node.lineno, 0, "type_comment",
+            )
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        # Process string annotation on annotated assignment
+        self._process_string_annotation(node.annotation)
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        if node.type_comment:
+            self._process_type_string(
+                node.type_comment, node.lineno, 0, "type_comment",
+            )
+        self.generic_visit(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        if node.type_comment:
+            self._process_type_string(
+                node.type_comment, node.lineno, 0, "type_comment",
+            )
+        self.generic_visit(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        if node.type_comment:
+            self._process_type_string(
+                node.type_comment, node.lineno, 0, "type_comment",
+            )
+        self.generic_visit(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        if node.type_comment:
+            self._process_type_string(
+                node.type_comment, node.lineno, 0, "type_comment",
+            )
+        self.generic_visit(node)
+
+
+def collect_type_string_attr_usages(
+    tree: ast.AST,
+    module_imports: set[str],
+) -> list[TypeStringAttrUsage]:
+    """Collect module.attr usages from type comments and string annotations."""
+    visitor = TypeStringAttributeCollector(module_imports)
+    visitor.visit(tree)
+    return visitor.usages
+
+
 def collect_dunder_all_names(tree: ast.AST) -> set[str]:
     """Collect names exported via __all__.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ enable_error_code = [
 
 [[tool.mypy.overrides]]
 module = "tests.*"
-disable_error_code = ["var-annotated", "has-type"]
+disable_error_code = ["var-annotated", "has-type", "misc"]
 disallow_untyped_defs = false
 
 [tool.isort]

--- a/tests/type_annotations_test.py
+++ b/tests/type_annotations_test.py
@@ -292,3 +292,533 @@ def test_string_annotation_attribute_access_noop(s):
 def test_string_literal_not_annotation(s, expected):
     """Test that string literals outside annotation contexts don't count as usage."""
     assert _get_unused_names(s) == expected
+
+
+# =============================================================================
+# typing.cast() - first argument is annotation context
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # cast with direct type
+        pytest.param(
+            'from typing import cast, Optional\n'
+            '\n'
+            'x = cast(Optional[int], None)\n',
+            id='cast with direct type',
+        ),
+        # cast with string type
+        pytest.param(
+            'from typing import cast, Optional\n'
+            '\n'
+            'x = cast("Optional[int]", None)\n',
+            id='cast with string type',
+        ),
+        # cast with imported type
+        pytest.param(
+            'from typing import cast\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x = cast(Path, "./file")\n',
+            id='cast with imported type',
+        ),
+        # cast with forward reference
+        pytest.param(
+            'from typing import cast\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x = cast("Path", "./file")\n',
+            id='cast with forward reference',
+        ),
+    ),
+)
+def test_typing_cast_noop(s):
+    """Test that types used in typing.cast() are NOT flagged."""
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# TypeVar - constraints and bound are annotation contexts
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # TypeVar with direct bound
+        pytest.param(
+            'from typing import TypeVar, List\n'
+            '\n'
+            'T = TypeVar("T", bound=List)\n',
+            id='TypeVar with direct bound',
+        ),
+        # TypeVar with string bound
+        pytest.param(
+            'from typing import TypeVar, List\n'
+            '\n'
+            'T = TypeVar("T", bound="List")\n',
+            id='TypeVar with string bound',
+        ),
+        # TypeVar with direct constraints
+        pytest.param(
+            'from typing import TypeVar\n'
+            '\n'
+            'T = TypeVar("T", int, str)\n',
+            id='TypeVar with direct constraints',
+        ),
+        # TypeVar with string constraints
+        pytest.param(
+            'from typing import TypeVar, List, Dict\n'
+            '\n'
+            'T = TypeVar("T", "List", "Dict")\n',
+            id='TypeVar with string constraints',
+        ),
+        # TypeVar with mixed constraints
+        pytest.param(
+            'from typing import TypeVar, List\n'
+            '\n'
+            'T = TypeVar("T", int, "List")\n',
+            id='TypeVar with mixed constraints',
+        ),
+    ),
+)
+def test_typevar_noop(s):
+    """Test that types used in TypeVar constraints/bound are NOT flagged."""
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# typing.Literal - contents are NOT annotation context
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        # Literal with string that looks like type
+        pytest.param(
+            'from typing import Literal\n'
+            'from pathlib import Path\n'
+            '\n'
+            'def f(x: Literal["Path"]) -> None:\n'
+            '    pass\n',
+            {'Path'},
+            id='Literal string is NOT type reference',
+        ),
+        # Literal with multiple strings
+        pytest.param(
+            'from typing import Literal\n'
+            'from typing import Optional\n'
+            '\n'
+            'def f(x: Literal["Optional", "None"]) -> None:\n'
+            '    pass\n',
+            {'Optional'},
+            id='Literal strings are NOT type references',
+        ),
+    ),
+)
+def test_literal_contents_not_annotation(s, expected):
+    """Test that strings inside Literal[] are NOT treated as type annotations."""
+    assert _get_unused_names(s) == expected
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # Literal is itself used
+        pytest.param(
+            'from typing import Literal\n'
+            '\n'
+            'def f(x: Literal[1, 2, 3]) -> None:\n'
+            '    pass\n',
+            id='Literal type itself is used',
+        ),
+    ),
+)
+def test_literal_type_used_noop(s):
+    """Test that Literal type itself is counted as used."""
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# typing.Annotated - first arg is annotation, rest are metadata
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # Annotated with direct type
+        pytest.param(
+            'from typing import Annotated\n'
+            'from pathlib import Path\n'
+            '\n'
+            'def f(x: Annotated[Path, "metadata"]) -> None:\n'
+            '    pass\n',
+            id='Annotated with direct type',
+        ),
+        # Annotated with string type
+        pytest.param(
+            'from typing import Annotated\n'
+            'from pathlib import Path\n'
+            '\n'
+            'def f(x: Annotated["Path", "metadata"]) -> None:\n'
+            '    pass\n',
+            id='Annotated with string type',
+        ),
+    ),
+)
+def test_annotated_first_arg_noop(s):
+    """Test that first argument of Annotated[] is treated as annotation."""
+    assert _get_unused_names(s) == set()
+
+
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        # Annotated metadata that looks like type should be flagged
+        pytest.param(
+            'from typing import Annotated\n'
+            'from pathlib import Path\n'
+            'from typing import Optional\n'
+            '\n'
+            'def f(x: Annotated[Path, "Optional"]) -> None:\n'
+            '    pass\n',
+            {'Optional'},
+            id='Annotated metadata string NOT type reference',
+        ),
+    ),
+)
+def test_annotated_metadata_not_annotation(s, expected):
+    """Test that metadata args in Annotated[] are NOT treated as type annotations."""
+    assert _get_unused_names(s) == expected
+
+
+# =============================================================================
+# Partially quoted annotations (quotes inside non-quoted context)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # Quoted type inside Optional
+        pytest.param(
+            'from typing import Optional\n'
+            'from queue import Queue\n'
+            '\n'
+            'def f() -> Optional["Queue[str]"]:\n'
+            '    return None\n',
+            id='quoted Queue inside Optional',
+        ),
+        # Quoted type inside Callable
+        pytest.param(
+            'from typing import Callable\n'
+            'from queue import Queue\n'
+            '\n'
+            'Func = Callable[["Queue[str]"], None]\n',
+            id='quoted Queue inside Callable',
+        ),
+    ),
+)
+def test_partially_quoted_annotation_noop(s):
+    """Test that partially quoted types inside generics are properly detected."""
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# TypeAlias - RHS is annotation context when annotated with TypeAlias
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # TypeAlias with direct type
+        pytest.param(
+            'from typing import TypeAlias\n'
+            'from pathlib import Path\n'
+            '\n'
+            'PathAlias: TypeAlias = Path\n',
+            id='TypeAlias with direct type',
+        ),
+        # TypeAlias with string type
+        pytest.param(
+            'from typing import TypeAlias\n'
+            'from pathlib import Path\n'
+            '\n'
+            'PathAlias: TypeAlias = "Path"\n',
+            id='TypeAlias with string type',
+        ),
+    ),
+)
+def test_typealias_noop(s):
+    """Test that RHS of TypeAlias annotation is treated as type context."""
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# Edge cases: whitespace, line continuations, semicolons, mixed types
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # Extra whitespace in annotation
+        pytest.param(
+            'from pathlib import Path\n'
+            '\n'
+            'def f(x:   Path  ) -> None:\n'
+            '    pass\n',
+            id='extra spaces in annotation',
+        ),
+        # Tabs in annotation
+        pytest.param(
+            'from pathlib import Path\n'
+            '\n'
+            'def f(x:\tPath) -> None:\n'
+            '    pass\n',
+            id='tab in annotation',
+        ),
+        # Trailing whitespace in string annotation (leading causes IndentationError)
+        pytest.param(
+            'from pathlib import Path\n'
+            '\n'
+            'def f(x: "Path  ") -> None:\n'
+            '    pass\n',
+            id='trailing spaces in string annotation',
+        ),
+        # Newline in multiline string annotation
+        pytest.param(
+            'from typing import Dict\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x: """Dict[\n'
+            '    str,\n'
+            '    Path\n'
+            ']""" = {}\n',
+            id='multiline string annotation',
+        ),
+    ),
+)
+def test_whitespace_variations_noop(s):
+    """Test that various whitespace patterns are handled correctly."""
+    assert _get_unused_names(s) == set()
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # Backslash continuation in import
+        pytest.param(
+            'from pathlib \\\n'
+            '    import Path\n'
+            '\n'
+            'x: Path\n',
+            id='backslash in import',
+        ),
+        # Backslash continuation in annotation expression
+        pytest.param(
+            'from typing import Optional\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x: Optional[\\\n'
+            '    Path\\\n'
+            '] = None\n',
+            id='backslash in annotation',
+        ),
+        # Backslash continuation in function signature
+        pytest.param(
+            'from pathlib import Path\n'
+            '\n'
+            'def f(\\\n'
+            '    x: Path\\\n'
+            ') -> None:\n'
+            '    pass\n',
+            id='backslash in function signature',
+        ),
+    ),
+)
+def test_backslash_continuation_noop(s):
+    """Test that backslash line continuations are handled correctly."""
+    assert _get_unused_names(s) == set()
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # Semicolon with annotation on same line
+        pytest.param(
+            'from pathlib import Path; x: Path = Path(".")\n',
+            id='semicolon before annotation',
+        ),
+        # Multiple annotations on same line
+        pytest.param(
+            'from pathlib import Path\n'
+            'x: Path; y: Path\n',
+            id='multiple annotations same line',
+        ),
+        # Import and usage on same line
+        pytest.param(
+            'from pathlib import Path; p: Path = Path(".")\n',
+            id='import and annotation same line',
+        ),
+    ),
+)
+def test_semicolon_statements_noop(s):
+    """Test that semicolon-separated statements are handled correctly."""
+    assert _get_unused_names(s) == set()
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # Mixed direct and string in Union
+        pytest.param(
+            'from typing import Union\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x: Union[str, "Path"] = ""\n',
+            id='Union with mixed direct and string',
+        ),
+        # Mixed direct and string in Optional
+        pytest.param(
+            'from typing import Optional\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x: Optional["Path"] = None\n',
+            id='Optional with string type',
+        ),
+        # Nested mixed - string inside direct generic
+        pytest.param(
+            'from typing import List, Optional\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x: List[Optional["Path"]] = []\n',
+            id='nested string in direct generic',
+        ),
+        # Multiple string refs in same annotation
+        pytest.param(
+            'from typing import Dict\n'
+            'from pathlib import Path\n'
+            'from io import StringIO\n'
+            '\n'
+            'x: "Dict[Path, StringIO]" = {}\n',
+            id='multiple types in single string annotation',
+        ),
+        # Mixed: some in string, some direct
+        pytest.param(
+            'from typing import Tuple\n'
+            'from pathlib import Path\n'
+            'from io import StringIO\n'
+            '\n'
+            'x: Tuple["Path", StringIO, "Path"] = (Path("."), StringIO(), Path("."))\n',
+            id='mixed string and direct in Tuple',
+        ),
+    ),
+)
+def test_mixed_forward_refs_noop(s):
+    """Test that mixed forward references and direct types work correctly."""
+    assert _get_unused_names(s) == set()
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # cast with extra whitespace
+        pytest.param(
+            'from typing import cast\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x = cast(  "Path"  , None)\n',
+            id='cast with extra whitespace',
+        ),
+        # cast with line continuation
+        pytest.param(
+            'from typing import cast\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x = cast(\\\n'
+            '    "Path",\\\n'
+            '    None)\n',
+            id='cast with backslash continuation',
+        ),
+        # TypeVar with extra whitespace
+        pytest.param(
+            'from typing import TypeVar, List\n'
+            '\n'
+            'T = TypeVar(  "T"  ,   bound = "List"  )\n',
+            id='TypeVar with extra whitespace',
+        ),
+        # TypeVar with line continuation
+        pytest.param(
+            'from typing import TypeVar, List, Dict\n'
+            '\n'
+            'T = TypeVar(\\\n'
+            '    "T",\\\n'
+            '    "List",\\\n'
+            '    "Dict"\\\n'
+            ')\n',
+            id='TypeVar with backslash continuation',
+        ),
+        # Literal with semicolon nearby
+        pytest.param(
+            'from typing import Literal\n'
+            'x: Literal["a"]; y: Literal["b"]\n',
+            id='Literal with semicolons',
+        ),
+        # Annotated with complex whitespace
+        pytest.param(
+            'from typing import Annotated\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x: Annotated[  "Path"  ,  "metadata"  ] = Path(".")\n',
+            id='Annotated with extra whitespace',
+        ),
+    ),
+)
+def test_typing_constructs_edge_cases_noop(s):
+    """Test typing constructs with edge case formatting."""
+    assert _get_unused_names(s) == set()
+
+
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        # Literal with whitespace - still should flag unused import
+        pytest.param(
+            'from typing import Literal\n'
+            'from pathlib import Path\n'
+            '\n'
+            'x: Literal[  "Path"  ] = "Path"\n',
+            {'Path'},
+            id='Literal with whitespace still not type ref',
+        ),
+        # Annotated metadata with whitespace - still should flag
+        pytest.param(
+            'from typing import Annotated\n'
+            'from pathlib import Path\n'
+            'from typing import Optional\n'
+            '\n'
+            'x: Annotated[  Path  ,  "Optional"  ] = Path(".")\n',
+            {'Optional'},
+            id='Annotated metadata with whitespace still not type ref',
+        ),
+        # Leading whitespace in string annotation causes IndentationError when parsing
+        # This matches pyflakes behavior (ForwardAnnotationSyntaxError)
+        pytest.param(
+            'from pathlib import Path\n'
+            '\n'
+            'def f(x: "  Path") -> None:\n'
+            '    pass\n',
+            {'Path'},
+            id='leading spaces in string annotation unparseable',
+        ),
+    ),
+)
+def test_edge_cases_still_flag_unused(s, expected):
+    """Test that edge case formatting doesn't break detection of truly unused imports."""
+    assert _get_unused_names(s) == expected

--- a/tests/type_comments_test.py
+++ b/tests/type_comments_test.py
@@ -1,0 +1,401 @@
+"""Tests for PEP 484 type comment handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from import_analyzer import find_unused_imports
+
+
+def _get_unused_names(source: str) -> set[str]:
+    """Get set of unused import names from source code."""
+    return {imp.name for imp in find_unused_imports(source)}
+
+
+# =============================================================================
+# Variable type comments (should NOT flag as unused)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import Optional\n"
+            "x = None  # type: Optional[int]\n",
+            id="simple variable type comment",
+        ),
+        pytest.param(
+            "from typing import List\n"
+            "items = []  # type: List[int]\n",
+            id="list type comment",
+        ),
+        pytest.param(
+            "from typing import Dict, List\n"
+            "data = {}  # type: Dict[str, List[int]]\n",
+            id="nested generic type comment",
+        ),
+        pytest.param(
+            "from typing import Dict, List, Optional\n"
+            "data = {}  # type: Dict[str, List[Optional[int]]]\n",
+            id="deeply nested generic type comment",
+        ),
+        pytest.param(
+            "import typing\n"
+            "x = None  # type: typing.Optional[int]\n",
+            id="qualified type in comment",
+        ),
+        pytest.param(
+            "from typing import Tuple\n"
+            "x, y = 1, 2  # type: Tuple[int, str]\n",
+            id="tuple unpacking type comment",
+        ),
+        pytest.param(
+            "from typing import Union\n"
+            "x = None  # type: Union[int, str]\n",
+            id="union type comment",
+        ),
+        pytest.param(
+            "from typing import Callable\n"
+            "f = None  # type: Callable[[int], str]\n",
+            id="callable type comment",
+        ),
+    ),
+)
+def test_variable_type_comment_noop(s):
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# Function signature type comments (should NOT flag as unused)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "def foo(a, b):  # type: (int, str) -> bool\n"
+            "    return True\n",
+            id="basic function signature",
+        ),
+        pytest.param(
+            "from typing import Optional\n"
+            "def foo(a):  # type: (int) -> Optional[str]\n"
+            "    return None\n",
+            id="function with optional return",
+        ),
+        pytest.param(
+            "from typing import List, Dict\n"
+            "def foo(x):  # type: (Dict[str, int]) -> List[str]\n"
+            "    return []\n",
+            id="function with generic args and return",
+        ),
+        pytest.param(
+            "def foo(*args):  # type: (...)\n"
+            "    pass\n",
+            id="function with ellipsis args",
+        ),
+        pytest.param(
+            "def foo(*args, **kwargs):  # type: (*int, **str)\n"
+            "    pass\n",
+            id="function with starred type args",
+        ),
+        pytest.param(
+            "from typing import List, Optional\n"
+            "def foo(x):  # type: (List[Optional[int]]) -> Optional[List[str]]\n"
+            "    return None\n",
+            id="function with nested generics",
+        ),
+    ),
+)
+def test_function_signature_type_comment_noop(s):
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# Per-argument type comments (should NOT flag as unused)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import List\n"
+            "def foo(\n"
+            "    a,  # type: int\n"
+            "    b,  # type: List[str]\n"
+            "):\n"
+            "    pass\n",
+            id="per-argument type comments",
+        ),
+        pytest.param(
+            "from typing import Optional\n"
+            "def foo(\n"
+            "    x,  # type: Optional[int]\n"
+            "):\n"
+            "    # type: (...)\n"
+            "    pass\n",
+            id="per-arg with body type comment",
+        ),
+    ),
+)
+def test_per_argument_type_comment_noop(s):
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# For loop type comments (should NOT flag as unused)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import List\n"
+            "items = []  # type: List[int]\n"
+            "for x in items:  # type: int\n"
+            "    pass\n",
+            id="for loop type comment",
+        ),
+        pytest.param(
+            "from typing import Tuple, List\n"
+            "pairs = []  # type: List[Tuple[int, str]]\n"
+            "for x, y in pairs:  # type: Tuple[int, str]\n"
+            "    pass\n",
+            id="for loop tuple unpacking type comment",
+        ),
+    ),
+)
+def test_for_loop_type_comment_noop(s):
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# With statement type comments (should NOT flag as unused)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import TextIO\n"
+            "with open('f') as fp:  # type: TextIO\n"
+            "    pass\n",
+            id="with statement type comment",
+        ),
+    ),
+)
+def test_with_statement_type_comment_noop(s):
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# Async variants (should NOT flag as unused)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import Optional\n"
+            "async def foo(a):  # type: (int) -> Optional[str]\n"
+            "    return None\n",
+            id="async function type comment",
+        ),
+    ),
+)
+def test_async_type_comment_noop(s):
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# PEP 526 precedence over type comments
+# =============================================================================
+
+
+# Note: For variable annotations (AnnAssign), Python's AST parser rejects
+# having both annotation AND type comment when type_comments=True.
+# So we only test function cases where both can coexist.
+
+
+@pytest.mark.parametrize(
+    ("s", "expected"),
+    (
+        pytest.param(
+            "from typing import Optional, List\n"
+            "def foo(a: int) -> Optional[str]:  # type: (List[int]) -> str\n"
+            "    return None\n",
+            {"List"},
+            id="function annotation takes precedence",
+        ),
+        pytest.param(
+            "from typing import List, Dict\n"
+            "def foo(\n"
+            "    a: int,  # type: List[int]\n"
+            "):\n"
+            "    pass\n",
+            {"List", "Dict"},
+            id="per-arg annotation takes precedence",
+        ),
+    ),
+)
+def test_pep526_precedence(s, expected):
+    assert _get_unused_names(s) == expected
+
+
+# =============================================================================
+# "type: ignore" is skipped (not a type annotation)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import List\n"
+            "x = []  # type: ignore\n",
+            id="type ignore on assignment",
+        ),
+        pytest.param(
+            "from typing import Optional\n"
+            "def foo(a):  # type: ignore\n"
+            "    pass\n",
+            id="type ignore on function",
+        ),
+        pytest.param(
+            "from typing import Dict\n"
+            "x = {}  # type: ignore[assignment]\n",
+            id="type ignore with code",
+        ),
+    ),
+)
+def test_type_ignore_flags_unused(s):
+    # "type: ignore" comments should NOT count as usage
+    unused = _get_unused_names(s)
+    assert len(unused) > 0  # The import should be flagged as unused
+
+
+# =============================================================================
+# Edge cases - syntax anomalies handled by AST
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import List\n"
+            "x = 1; y = []  # type: List[int]\n",
+            id="semicolon separated - type comment on last",
+        ),
+        pytest.param(
+            "from typing import Optional\n"
+            "x = \\\n"
+            "    None  # type: Optional[int]\n",
+            id="backslash continuation",
+        ),
+        pytest.param(
+            "from typing import List\n"
+            "x = []  # type: List[int]  # some other comment\n",
+            id="type comment with trailing comment",
+        ),
+        pytest.param(
+            "from typing import Dict\n"
+            "x = {}  #type:Dict[str,int]\n",
+            id="no spaces in type comment",
+        ),
+        pytest.param(
+            "from typing import List\n"
+            "x = []  #  type:   List[int]  \n",
+            id="extra whitespace in type comment",
+        ),
+        pytest.param(
+            "from typing import Optional\n"
+            "x = None\t# type:\tOptional[int]\n",
+            id="tabs in type comment",
+        ),
+    ),
+)
+def test_edge_cases_noop(s):
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# Invalid type comments (gracefully ignored)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import List\n"
+            "x = []  # type: List[\n",
+            id="invalid type syntax - unclosed bracket",
+        ),
+        pytest.param(
+            "from typing import Dict\n"
+            "x = {}  # type: ???\n",
+            id="invalid type syntax - invalid chars",
+        ),
+    ),
+)
+def test_invalid_type_comment_flags_unused(s):
+    # Invalid type comments should not crash, and import should be unused
+    unused = _get_unused_names(s)
+    assert len(unused) > 0
+
+
+# =============================================================================
+# Nested functions and classes
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import Optional\n"
+            "class Foo:\n"
+            "    def bar(self, x):  # type: (int) -> Optional[str]\n"
+            "        return None\n",
+            id="method type comment",
+        ),
+        pytest.param(
+            "from typing import List\n"
+            "def outer():\n"
+            "    def inner(x):  # type: (int) -> List[str]\n"
+            "        return []\n"
+            "    return inner\n",
+            id="nested function type comment",
+        ),
+    ),
+)
+def test_nested_type_comment_noop(s):
+    assert _get_unused_names(s) == set()
+
+
+# =============================================================================
+# Forward references in type comments
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        pytest.param(
+            "from typing import Optional\n"
+            "x = None  # type: Optional['Foo']\n"
+            "class Foo:\n"
+            "    pass\n",
+            id="forward reference in type comment",
+        ),
+    ),
+)
+def test_forward_reference_type_comment_noop(s):
+    assert _get_unused_names(s) == set()


### PR DESCRIPTION
- Updated the import analyzer to detect indirect attribute accesses in type comments and string annotations, allowing for more comprehensive analysis.
- Introduced `TypeStringAttrUsage` to represent usages found in type comments and string annotations.
- Modified `CrossFileAnalyzer` to collect and process these usages alongside regular code attribute accesses.
- Enhanced the autofix functionality to rewrite type comments and string annotations to use direct imports.
- Added tests to ensure correct detection and rewriting of indirect accesses in both type comments and string annotations.

This improvement aligns with Python's type hinting standards and enhances the tool's capability to manage indirect imports effectively.

## Summary
<!-- What does this PR do? Why is it needed? -->

## Testing Process
<!-- How was this tested? -->

## Checklist
- [ ] Added test coverage for code changes

Closes #<!-- issue number -->
